### PR TITLE
fix a bug that happens when variable names are minified

### DIFF
--- a/src/components/CloudinaryComponent/CloudinaryComponent.js
+++ b/src/components/CloudinaryComponent/CloudinaryComponent.js
@@ -26,7 +26,7 @@ class CloudinaryComponent extends Component {
     if(children === undefined || children === null) return null;
     let mapped = React.Children.map(children, child =>{
       let options = {};
-      if (child.type && child.type.name === "Transformation"){
+      if (child.type && child.type._type === "Transformation"){
         options = CloudinaryComponent.normalizeOptions(child.props, child.context);
       }
       let childOptions = this.getChildTransformations(child.props.children);

--- a/src/components/Transformation/Transformation.js
+++ b/src/components/Transformation/Transformation.js
@@ -5,6 +5,8 @@ import CloudinaryComponent from '../CloudinaryComponent';
  * Define a transformation that is applied to the parent tag.
  */
 class Transformation extends CloudinaryComponent {
+  static _type = "Transformation";
+  
   constructor(props) {
     super(props);
   }


### PR DESCRIPTION
React uses the function's name as the Component's display name, so when variables are minified `Transformation` may become `T`, and therefore a test such as `child.type.name === "Transformation"` evaluates to `false` causing transformations to be lost.