### PR TITLE
Update tests to fail when component is not exported

### DIFF
--- a/test/AudioTest.js
+++ b/test/AudioTest.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import chai, {expect} from 'chai';
 import {shallow, mount} from 'enzyme';
-import Audio from '../src/components/Audio';
-import Transformation from '../src/components/Transformation';
+import cloudinary from './cloudinary-proxy';
+const {Audio, Transformation} = cloudinary;
 
 chai.use(require('chai-string'));
 

--- a/test/VideoTest.js
+++ b/test/VideoTest.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import chai, {expect} from 'chai';
 import {shallow, mount} from 'enzyme';
-import Video from '../src/components/Video';
-import Transformation from '../src/components/Transformation';
-
+import cloudinary from './cloudinary-proxy';
+const {Video, Transformation} = cloudinary;
 chai.use(require('chai-string'));
 
 describe('Video', () => {


### PR DESCRIPTION
Align Video and Audio tests imports with that of Image's test, so that they will fail when the main index.js does not export a component. They would not fail before because they imported directly from /src. We should consider to simplify this in the future, I'd also consider switching to rollup.