### PR TITLE
Fix responsive placeholder

### DIFF
--- a/e2e-test/cypress/integration/placeholder.spec.js
+++ b/e2e-test/cypress/integration/placeholder.spec.js
@@ -4,10 +4,10 @@ describe('Placeholder Image', () => {
     cy.visit('/');
     cy.get('#placeholderBtn').click();
   });
-  
+
   /**
    * Cypress seems to be not fast enough to catch the placeholder render.
-   * So we test that the placeholder is rendered in out Unit Tests,
+   * So we test that the placeholder is rendered in our Unit Tests,
    * And here we make sure that eventually we render the original image.
    */
   it('Show original image', () => {

--- a/e2e-test/cypress/integration/responsivePlaceholder.spec.js
+++ b/e2e-test/cypress/integration/responsivePlaceholder.spec.js
@@ -1,0 +1,19 @@
+describe('Responsive Placeholder Image', () => {
+  beforeEach(() => {
+    // runs before each test in the block
+    cy.visit('/');
+    cy.get('#responsivePlaceholderBtn').click();
+  });
+
+  /**
+   * Cypress seems to be not fast enough to catch the placeholder render.
+   * So we test that the placeholder is rendered in our Unit Tests,
+   * And here we make sure that eventually we render the responsive image.
+   * The image width was updated to be w_400.
+   */
+  it('Show original image', () => {
+    cy.get('#responsivePlaceholder')
+      .should('be.visible')
+      .should('have.attr', 'src').should('equal', 'http://res.cloudinary.com/demo/image/upload/c_scale,w_400/sample')
+  });
+});

--- a/e2e-test/src/App.js
+++ b/e2e-test/src/App.js
@@ -7,7 +7,8 @@ const tests = [
   'placeholder',
   'lazy',
   'lazyPlaceholder',
-  'lazyResponsive'
+  'lazyResponsive',
+  'responsivePlaceholder'
 ];
 
 function App() {
@@ -80,6 +81,17 @@ function App() {
                    responsive>
             </Image>
           </div>
+        </div>
+      </div>
+      }
+      }
+      {test === 'responsivePlaceholder' &&
+      <div>
+        <h1>Responsive Placeholder</h1>
+        <div style={{width: "330px"}}>
+          <Image id="responsivePlaceholder" publicId="sample" cloudName="demo" width="auto" crop="scale" responsive>
+            <Placeholder/>
+          </Image>
         </div>
       </div>
       }

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -43,7 +43,7 @@ class Image extends CloudinaryComponent {
     const extendedProps = this.getExtendedProps();
     const {children, innerRef, ...options} = {...extendedProps, ...this.getTransformation(extendedProps)};
 
-    if (!this.shouldLazyLoad()) {
+    if (!this.shouldLazyLoad()){
       delete options.loading;
     }
 
@@ -81,7 +81,7 @@ class Image extends CloudinaryComponent {
     // Remove unneeded attributes,
     ['dataSrc', 'accessibility', 'placeholder', 'breakpoints'].forEach(attr => {
       delete attributes[attr];
-    })
+    });
 
     return attributes;
   }
@@ -100,12 +100,13 @@ class Image extends CloudinaryComponent {
         const options = this.getOptions();
         const placeholder = this.getPlaceholderType();
 
+        // Make placeholder responsive
         if (placeholder) {
-          const placeholderOptions = {...options, placeholder};
-          const removePlaceholderListener = makeElementResponsive(this.placeholderElement.current, placeholderOptions);
+          const removePlaceholderListener = makeElementResponsive(this.placeholderElement.current, {...options, placeholder});
           this.listenerRemovers.push(removePlaceholderListener);
         }
 
+        // Make original image responsive
         const removeImgListener = makeElementResponsive(this.imgElement.current, options);
         this.listenerRemovers.push(removeImgListener);
       }
@@ -192,7 +193,7 @@ class Image extends CloudinaryComponent {
   getPlaceholderType = () => {
     const {children} = this.getExtendedProps();
     const placeholder = this.getChildPlaceholder(children);
-    
+
     return placeholder ? placeholder.props.type : null;
   }
 

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -192,11 +192,8 @@ class Image extends CloudinaryComponent {
   getPlaceholderType = () => {
     const {children} = this.getExtendedProps();
     const placeholder = this.getChildPlaceholder(children);
-    if (!placeholder) {
-      return null;
-    }
-
-    return placeholder.props.type;
+    
+    return placeholder ? placeholder.props.type : null;
   }
 
   render() {

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -202,11 +202,11 @@ class Image extends CloudinaryComponent {
   render() {
     const {isLoaded} = this.state;
     const attributes = this.getAttributes();
-    const placeholderType = this.getPlaceholderType();
+    const placeholder = this.getPlaceholderType();
 
     //If image wasn't loaded and there's a child placeholder then we render it.
-    if (!isLoaded && placeholderType) {
-      return this.renderPlaceholder(placeholderType, attributes);
+    if (!isLoaded && placeholder) {
+      return this.renderPlaceholder(placeholder, attributes);
     }
 
     return this.renderImage(attributes);

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -186,7 +186,7 @@ class Image extends CloudinaryComponent {
   };
 
   renderImage = (attributes) => {
-    return <img key="cld-image" ref={this.attachRef} {...attributes}/>
+    return <img ref={this.attachRef} {...attributes}/>
   }
 
   getPlaceholderType = () => {

--- a/test/ImageTest.js
+++ b/test/ImageTest.js
@@ -205,6 +205,21 @@ describe('Image', () => {
         ].join(''));
       });
     });
+    describe('Responsive Placeholder', () => {
+      let tag = shallow(
+        <Image publicId="sample" cloudName="demo" width="auto" crop="scale" responsive>
+          <Placeholder/>
+        </Image>
+      );
+      it('should have data-src for placeholder and image', function () {
+        expect(tag.html()).to.equal([
+          `<img data-src="http://res.cloudinary.com/demo/image/upload/c_scale,w_auto/sample" style="opacity:0;position:absolute"/>`,
+          `<div style="display:inline">`,
+          `<img data-src="http://res.cloudinary.com/demo/image/upload/c_scale,w_auto/e_blur:2000,f_auto,q_1/sample"/>`,
+          `</div>`
+        ].join(''));
+      });
+    });
     describe('Responsive Placeholder With Lazy Loading', () => {
       let tag = shallow(
         <Image publicId="sample" cloudName="demo" loading="lazy" width="auto" crop="scale" responsive>


### PR DESCRIPTION
This fixes responsive placeholder, by adding a call to cloudinary.responsive for the placeholder image.
I've added ref to the placeholder image, so it can be passed to makeImageResponsive()
Also, added getPlaceholderType() function to better organize the code