### PR TITLE
Fix incorrect lazy loading of placeholders and incorrect eager loading where browsers support native lazy loading

### DIFF
--- a/src/components/CloudinaryComponent/CloudinaryComponent.js
+++ b/src/components/CloudinaryComponent/CloudinaryComponent.js
@@ -56,7 +56,7 @@ class CloudinaryComponent extends PureComponent {
   /**
    * React function: Called when this element is in view
    */
-  onIntersect = () =>{
+  onIntersect = () => {
     this.setState({isInView: true})
   }
 

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -43,7 +43,7 @@ class Image extends CloudinaryComponent {
     const extendedProps = this.getExtendedProps();
     const {children, innerRef, ...options} = {...extendedProps, ...this.getTransformation(extendedProps)};
 
-    if (!this.shouldLazyLoad()){
+    if (!this.shouldLazyLoad() && !Util.isNativeLazyLoadSupported()){
       delete options.loading;
     }
 
@@ -62,6 +62,10 @@ class Image extends CloudinaryComponent {
     // React requires camelCase instead of snake_case attributes
     const attributes = ({...Util.withCamelCaseKeys(getImageTag(options).attributes()), ...nonCloudinaryProps});
 
+    if (placeholder) {
+      delete attributes.loading
+    }
+
     // We want to keep 'data-src' if it exists
     if (attributes.dataSrc) {
       attributes['data-src'] = attributes.dataSrc;
@@ -72,8 +76,8 @@ class Image extends CloudinaryComponent {
       attributes.id = attributes.id + '-cld-placeholder';
     }
 
-    // Set data-src if lazy loading, not in view, and not a placeholder
-    if (!placeholder && this.shouldLazyLoad()) {
+    // Set data-src if lazy loading and not in view
+    if (this.shouldLazyLoad()) {
       attributes['data-src'] = attributes.dataSrc || attributes.src;
       delete attributes.src;
     }
@@ -130,10 +134,13 @@ class Image extends CloudinaryComponent {
     }
   };
 
+
+
   shouldLazyLoad = () => {
     const {loading} = this.getExtendedProps();
+    const isLoadingDesired = (loading === "lazy" || loading === "auto")
     const {isInView} = this.state;
-    return !isInView && (loading === "lazy" || loading === "auto");
+    return !isInView && isLoadingDesired;
   }
 
   /**

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -134,8 +134,6 @@ class Image extends CloudinaryComponent {
     }
   };
 
-
-
   shouldLazyLoad = () => {
     const {loading} = this.getExtendedProps();
     const isLoadingDesired = (loading === "lazy" || loading === "auto")

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -72,8 +72,8 @@ class Image extends CloudinaryComponent {
       attributes.id = attributes.id + '-cld-placeholder';
     }
 
-    // Set data-src if lazy loading and not in view
-    if (this.shouldLazyLoad()) {
+    // Set data-src if lazy loading, not in view, and not a placeholder
+    if (!placeholder && this.shouldLazyLoad()) {
       attributes['data-src'] = attributes.dataSrc || attributes.src;
       delete attributes.src;
     }

--- a/test/ImageTest.js
+++ b/test/ImageTest.js
@@ -177,11 +177,11 @@ describe('Image', () => {
         </Image>
       );
 
-      it('should have data-src for placeholder and image', function () {
+      it('should have data-src for placeholder and image, with lazy for image only', function () {
         expect(tag.html()).to.equal([
           `<img loading="lazy" data-src="http://res.cloudinary.com/demo/image/upload/sample" style="opacity:0;position:absolute"/>`,
           `<div style="display:inline">`,
-          `<img loading="lazy" data-src="http://res.cloudinary.com/demo/image/upload/e_blur:2000,f_auto,q_1/sample"/>`,
+          `<img data-src="http://res.cloudinary.com/demo/image/upload/e_blur:2000,f_auto,q_1/sample"/>`,
           `</div>`
         ].join(''));
       });
@@ -226,11 +226,11 @@ describe('Image', () => {
           <Placeholder/>
         </Image>
       );
-      it('should have data-src for placeholder and image', function () {
+      it('should have data-src for image and placeholder, with lazy for image only', function () {
         expect(tag.html()).to.equal([
           `<img loading="lazy" data-src="http://res.cloudinary.com/demo/image/upload/c_scale,w_auto/sample" style="opacity:0;position:absolute"/>`,
           `<div style="display:inline">`,
-          `<img loading="lazy" data-src="http://res.cloudinary.com/demo/image/upload/c_scale,w_auto/e_blur:2000,f_auto,q_1/sample"/>`,
+          `<img data-src="http://res.cloudinary.com/demo/image/upload/c_scale,w_auto/e_blur:2000,f_auto,q_1/sample"/>`,
           `</div>`
         ].join(''));
       });


### PR DESCRIPTION
When used in conjunction with https://github.com/cloudinary/cloudinary_js/pull/258, this fixes #186.

This also provides a partial solution to #187 by correcting failing behaviour exposed by the other PR mentioned above.

## Placeholders
The `loading` attribute was incorrectly applied to placeholders, meaning that these were lazy loaded, contrary to the documentation here: https://cloudinary.com/documentation/react_image_manipulation#image_placeholders

This change removes any loading attributes from placeholders.

## Native Lazy Loading
The `Utils.detectIntersection` method called in the `Image` component refers to https://github.com/cloudinary/cloudinary_js/blob/master/src/util/lazyLoad.js#L28.

There is currently an issue where in at least some browsers which support Native Lazyload, this incorrectly adds `IntersectionObserver`. The above PR (https://github.com/cloudinary/cloudinary_js/pull/258) fixes this.

However, once this is fixed it exposes an issue on this component. The `detectIntersection` method immediately calls `CloudinaryComponent.onIntersect`, and with the current logic this means the application assumes _every_ image is inView, and thus the lazy loading attributes are deleted.

As a simple fix for this I've added some protection by only deleting the loading attributes if `Util.isNativeLazyLoadSupported()` is falsey.

There may be a more elegant fix for this, but at least in my testing this appears to work.