### PR TITLE
Reload video on props change

### DIFF
--- a/bundlewatch.config.js
+++ b/bundlewatch.config.js
@@ -2,7 +2,7 @@ const bundlewatchConfig = {
   files: [
     {
       path: './dist/cloudinary-react.js',
-      maxSize: '44kb'
+      maxSize: '44.5kb'
     }
   ],
   defaultCompression: 'gzip',

--- a/e2e-test/package.json
+++ b/e2e-test/package.json
@@ -35,6 +35,7 @@
     ]
   },
   "devDependencies": {
+    "typescript": "^3.7.2",
     "cypress": "^4.9.0",
     "start-server-and-test": "^1.11.0"
   }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "mocha": "^8.0.1",
     "npm-run-all": "^4.1.5",
     "react-dom": "^16.3.3",
+    "sinon": "^9.2.1",
+    "sinon-chai": "^3.5.0",
     "webpack": "4.27.1",
     "webpack-cli": "^3.1.2"
   },

--- a/src/components/CloudinaryComponent/CloudinaryComponent.js
+++ b/src/components/CloudinaryComponent/CloudinaryComponent.js
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react';
+import React, {PureComponent, createRef} from 'react';
 import PropTypes from 'prop-types';
 import {Transformation, Util} from 'cloudinary-core';
 import {CloudinaryContextType} from '../CloudinaryContext/CloudinaryContextType';
@@ -43,6 +43,7 @@ function only(source, keys = []) {
 class CloudinaryComponent extends PureComponent {
   constructor(props, context) {
     super(props, context);
+    this.element = createRef();
   }
 
   render() {
@@ -156,6 +157,23 @@ class CloudinaryComponent extends PureComponent {
    */
   getExtendedProps = (props = this.props, context = this.getContext()) => {
     return CloudinaryComponent.normalizeOptions(context, props);
+  };
+
+  /**
+   * Attach both this.element and props.innerRef as ref to the given element
+   * @param element - the element to attach a ref to
+   */
+  attachRef = (element) => {
+    const {innerRef} = this.props;
+    this.element.current = element;
+
+    if (innerRef) {
+      if (innerRef instanceof Function) {
+        innerRef(element);
+      } else {
+        innerRef.current = element;
+      }
+    }
   };
 
   static contextType = CloudinaryContextType;

--- a/src/components/Image/Image.js
+++ b/src/components/Image/Image.js
@@ -18,7 +18,6 @@ const RESPONSIVE_OVERRIDE_WARNING = [
 class Image extends CloudinaryComponent {
   constructor(props, context) {
     super(props, context);
-    this.imgElement = createRef();
     this.placeholderElement = createRef();
     this.state = {isLoaded: false}
     this.listenerRemovers = [];
@@ -33,7 +32,7 @@ class Image extends CloudinaryComponent {
       console.warn(RESPONSIVE_OVERRIDE_WARNING);
     }
 
-    return responsive && this.imgElement && this.imgElement.current;
+    return responsive && this.element && this.element.current;
   }
 
   /**
@@ -95,7 +94,7 @@ class Image extends CloudinaryComponent {
     // Handle lazy loading
     if (this.shouldLazyLoad()) {
       // Will set this.state.isInView = true when in view
-      Util.detectIntersection(this.imgElement.current, this.onIntersect);
+      Util.detectIntersection(this.element.current, this.onIntersect);
     } else {
       // Handle responsive only if lazy loading wasn't requested or already handled
       if (this.isResponsive()) {
@@ -109,28 +108,11 @@ class Image extends CloudinaryComponent {
         }
 
         // Make original image responsive
-        const removeImgListener = makeElementResponsive(this.imgElement.current, options);
+        const removeImgListener = makeElementResponsive(this.element.current, options);
         this.listenerRemovers.push(removeImgListener);
       }
     }
   }
-
-  /**
-   * Attach both this.imgElement and props.innerRef as ref to the given element
-   * @param imgElement - the element to attach a ref to
-   */
-  attachRef = (imgElement) => {
-    const {innerRef} = this.props;
-    this.imgElement.current = imgElement;
-
-    if (innerRef) {
-      if (innerRef instanceof Function) {
-        innerRef(imgElement);
-      } else {
-        innerRef.current = imgElement;
-      }
-    }
-  };
 
   shouldLazyLoad = () => {
     const {loading} = this.getExtendedProps();

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -86,16 +86,17 @@ class Video extends CloudinaryComponent {
     const childTransformations = this.getTransformation({...options, children});
 
     let sources = null;
+    let videoElementKey = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
 
     if (Util.isArray(sourceTypes)) {
       // We have multiple sourceTypes, so we generate <source> tags.
       sources = this.generateSources(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
     } else {
-      // We have a single source type so we generate the src attribute of this video element.
-      tagAttributes.src = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
+      // We have a single source type so we use the already generated video url.
+      tagAttributes.src = videoElementKey;
     }
 
-    return {sources, tagAttributes};
+    return {sources, tagAttributes, videoElementKey};
   };
 
   /**
@@ -105,12 +106,14 @@ class Video extends CloudinaryComponent {
     const {innerRef, fallback, children} = this.props;
 
     const {
+      videoElementKey,
       tagAttributes, // Attributes of this video element
       sources        // <source> tags of this video element
     } = this.getVideoTagProps();
 
     return (
       <video
+        key={videoElementKey}
         ref={innerRef}
         {...tagAttributes}>
         {sources}

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -86,7 +86,7 @@ class Video extends CloudinaryComponent {
     const childTransformations = this.getTransformation({...options, children});
 
     let sources = null;
-    let videoElementKey = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
+    const videoElementKey = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
 
     if (Util.isArray(sourceTypes)) {
       // We have multiple sourceTypes, so we generate <source> tags.

--- a/src/components/Video/Video.js
+++ b/src/components/Video/Video.js
@@ -86,35 +86,45 @@ class Video extends CloudinaryComponent {
     const childTransformations = this.getTransformation({...options, children});
 
     let sources = null;
-    const videoElementKey = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
 
     if (Util.isArray(sourceTypes)) {
       // We have multiple sourceTypes, so we generate <source> tags.
       sources = this.generateSources(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
     } else {
-      // We have a single source type so we use the already generated video url.
-      tagAttributes.src = videoElementKey;
+      // We have a single source type so we generate the src attribute of this video element.
+      tagAttributes.src = this.generateVideoUrl(cld, publicId, childTransformations, sourceTransformation, sourceTypes);
     }
 
-    return {sources, tagAttributes, videoElementKey};
+    return {sources, tagAttributes};
   };
+
+  reloadVideo = () => {
+    if (this.element && this.element.current){
+      this.element.current.load();
+    }
+  }
+
+  componentDidUpdate() {
+    // Load video on props change
+    this.reloadVideo();
+  }
+
+
 
   /**
    * Render a video element
    */
   render() {
-    const {innerRef, fallback, children} = this.props;
+    const {fallback, children} = this.props;
 
     const {
-      videoElementKey,
       tagAttributes, // Attributes of this video element
       sources        // <source> tags of this video element
     } = this.getVideoTagProps();
 
     return (
       <video
-        key={videoElementKey}
-        ref={innerRef}
+        ref={this.attachRef}
         {...tagAttributes}>
         {sources}
         {fallback}

--- a/test/VideoTest.js
+++ b/test/VideoTest.js
@@ -199,4 +199,20 @@ describe('Video', () => {
     expect(video.prop('data-testid')).to.equal("testing");
     expect(video.prop('datatestid')).to.equal(undefined);
   });
+  it('should have a unique key prop that ends with all source types', () => {
+    let tag = mount(
+      <Video publicId="dog" cloudName="demo"/>
+    );
+
+    const video = tag.find('video');
+    expect(video.key()).to.equal('http://res.cloudinary.com/demo/video/upload/dog.webm,mp4,ogv');
+  });
+  it('should have a unique key prop that ends with no source type', () => {
+    let tag = mount(
+      <Video publicId="dog" cloudName="demo" sourceTypes={null}/>
+    );
+
+    const video = tag.find('video');
+    expect(video.key()).to.equal('http://res.cloudinary.com/demo/video/upload/dog');
+  });
 });

--- a/test/VideoTest.js
+++ b/test/VideoTest.js
@@ -1,7 +1,11 @@
 import React from 'react';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai'
 import chai, {expect} from 'chai';
 import {shallow, mount} from 'enzyme';
 import cloudinary from './cloudinary-proxy';
+chai.use(sinonChai);
+
 const {Video, Transformation} = cloudinary;
 chai.use(require('chai-string'));
 
@@ -199,20 +203,17 @@ describe('Video', () => {
     expect(video.prop('data-testid')).to.equal("testing");
     expect(video.prop('datatestid')).to.equal(undefined);
   });
-  it('should have a unique key prop that ends with all source types', () => {
-    let tag = mount(
-      <Video publicId="dog" cloudName="demo"/>
+  it('reloads video on props change', () => {
+    const tag = shallow(
+      <Video cloudName='demo' publicId='dog'/>
     );
 
-    const video = tag.find('video');
-    expect(video.key()).to.equal('http://res.cloudinary.com/demo/video/upload/dog.webm,mp4,ogv');
-  });
-  it('should have a unique key prop that ends with no source type', () => {
-    let tag = mount(
-      <Video publicId="dog" cloudName="demo" sourceTypes={null}/>
-    );
+    //detect calls for reloadVideo()
+    sinon.spy(tag.instance(), 'reloadVideo');
 
-    const video = tag.find('video');
-    expect(video.key()).to.equal('http://res.cloudinary.com/demo/video/upload/dog');
-  });
+    expect(tag.instance().reloadVideo).to.not.have.been.called;
+
+    tag.setProps({publicId: "cat"});
+    expect(tag.instance().reloadVideo).to.have.been.called;
+  })
 });


### PR DESCRIPTION
### Brief Summary of Changes
By reloading the video on props change we make it easier for users, because they do not need to pass a unique key to rerender on props change. 

#### What does this PR address?
- [ ] GitHub issue (Add reference - #XX)
- [ ] Refactoring
- [X] New feature
- [ ] Bug fix
- [X] Adds more tests

#### Are tests included?
- [X] Yes
- [ ] No

#### Reviewer, please note:
<!--
List anything here that the reviewer should pay special attention to. This might
include, for example:
* Dependence on other PRs
* Reference to other Cloudinary SDKs
* Changes that seem arbitrary without further explanations
-->

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I ran the full test suite before pushing the changes and all of the tests pass.
