### PR TITLE
Expand test for `normalize_expression` with more complex instances of reserved names

### DIFF
--- a/test/TransformationTest.js
+++ b/test/TransformationTest.js
@@ -79,13 +79,13 @@ describe("Transformation", () => {
   it("should not change variable names even if they are keywords", function () {
     const image = shallow(
       <Image publicId="sample" cloudName="demo">
-        <Transformation variables={[["$width", 10]]}/>
+        <Transformation variables={[["$width", 10], ["$myheight", 20], ["$heightheight", 30], ["$theheight", 40], ["$__height", 50]]}/>
         <Transformation width="$width + 10 + width" crop="scale"/>
       </Image>
     );
     expect(image.name()).to.equal("img");
     expect(image.props().src).to.equal(
-      "http://res.cloudinary.com/demo/image/upload/$width_10/c_scale,w_$width_add_10_add_w/sample"
+      "http://res.cloudinary.com/demo/image/upload/$width_10,$myheight_20,$heightheight_30,$theheight_40,$__height_50/c_scale,w_$width_add_10_add_w/sample"
     );
   });
 });


### PR DESCRIPTION
### Brief Summary of Changes

In previous versions of the JavaScript SDK some variables would be incorrectly normalized if their name contained a reserved keyword (e.g., `$myheight_100` would become `$myh_100` even though it shouldn't be normalized). This was fixed in the SDK and so is now also fixed in the React SDK.

This PR adds a test to verify that it indeed works/

#### What does this PR address?
- [x] Adds more tests

#### Are tests included?
- [x] Yes

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I ran the full test suite before pushing the changes and all of the tests pass.
