### PR TITLE
feat: add support for authToken prop

### DIFF
--- a/__tests__/image.test.js
+++ b/__tests__/image.test.js
@@ -195,6 +195,16 @@ describe('Image', () => {
 
     expect(tag.find('img').prop('src')).toEqual(expected);
   });
+  it('Should support authToken param', function () {
+    const authToken = 'ip=111.222.111.222~exp=1512982559~acl=%2fimage%2fauthenticated%2f%2a~hmac=b17360091889151e9c2e2a7c713a074fdd29dc4ef1cc2fb897a0764664f3c48d';
+    const expected = `http://res.cloudinary.com/demo/image/upload/sample?__cld_token__=${authToken}`;
+
+    const tag = mount(
+      <Image cloudName='demo' publicId='sample' authToken={authToken} />
+    );
+
+    expect(tag.find('img').prop('src')).toEqual(expected);
+  });
   describe('Responsive', () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation();
 

--- a/src/Util/cloudinaryReactUtils.js
+++ b/src/Util/cloudinaryReactUtils.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 const { camelCase, withCamelCaseKeys, isEmpty } = Util;
 
 // props passed to cloudinary-core but should not be rendered as dom attributes
-const CLOUDINARY_REACT_PROPS = ['accessibility', 'breakpoints', 'dataSrc', 'placeholder', 'publicId', 'signature'];
+const CLOUDINARY_REACT_PROPS = ['accessibility', 'breakpoints', 'dataSrc', 'placeholder', 'publicId', 'signature', 'authToken'];
 
 /**
  * Convert common video file extensions to mime types


### PR DESCRIPTION
### Brief Summary of Changes
Add support for passing authToken param to add an auth token to the generated url

#### What does this PR address?
Github issue: https://github.com/cloudinary/cloudinary-react/issues/242

#### Are tests included?
Yes